### PR TITLE
fix: alows otp full 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ const OTPInput = () => {
       <OtpInput
         otpCount={5}
         autoFocus={false}
-        onCodeFilled={(code: number) => {
+        onCodeFilled={(code: string) => {
           Alert.alert('Notification', `OTP is ${code}`);
         }}
-        onCodeChanged={(codes: number) => {
+        onCodeChanged={(codes: string) => {
           console.log({ codes });
         }}
       />

--- a/src/Type.ts
+++ b/src/Type.ts
@@ -34,12 +34,12 @@ export interface IOtpInput extends TextInputProps {
    * Callback function
    * Trigger when all text input fields are fulfill
    */
-  onCodeFilled?: (code: number) => void;
+  onCodeFilled?: (code: string) => void;
   /**
    * Callback function
    * Trigger when a field of the OTP is changed
    */
-  onCodeChanged?: (codes: number) => void;
+  onCodeChanged?: (codes: string) => void;
   /**
    * Entering animation using reanimated layout
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,9 +183,9 @@ export const OtpInput = ({
   };
 
   useEffect(() => {
-    onCodeChanged && onCodeChanged(Number(otpValue.join('')));
+    onCodeChanged && onCodeChanged(otpValue.join(''));
     if (otpValue && Number(otpValue.join('').length === otpCount) && onCodeFilled) {
-      onCodeFilled(Number(otpValue.join('')));
+      onCodeFilled(otpValue.join(''));
     }
   }, [otpValue]);
 


### PR DESCRIPTION
+ I want to enter OTP with all 0s. There is a bug: the onCodeFilled and onCodeChanged functions both log a single 0.
If correct it would be 6 zeros.
+ It happens when trying to cast to number form. I think we should leave it as a string, it will be better
+ I think this lib is not only used to enter OTP, but it can be used as a form of password input. So the user can enter 6 zeros